### PR TITLE
Fix build with older Apple Clang

### DIFF
--- a/lsqpack.c
+++ b/lsqpack.c
@@ -74,15 +74,16 @@ SOFTWARE.
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
-#ifdef _MSC_VER
-#  define FALL_THROUGH
-#endif
-
 #ifndef FALL_THROUGH
-#  if defined __has_attribute && __has_attribute (fallthrough)
-#    define FALL_THROUGH __attribute__ ((fallthrough))
+#  if 201710L < __STDC_VERSION__
+#    define FALL_THROUGH [[fallthrough]]
+#  elif ((__GNUC__ >= 7 && !defined __clang__)      \
+        || (defined __apple_build_version__         \
+            ? __apple_build_version__ >= 12000000   \
+            : __clang_major__ >= 10))
+#    define FALL_THROUGH __attribute__((fallthrough))
 #  else
-#    define FALL_THROUGH
+#    define FALL_THROUGH ((void)0)
 #  endif
 #endif
 


### PR DESCRIPTION
Fixes build on older macOS (10.7-10.9): https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/303788

Sources:
- https://stackoverflow.com/questions/45349079/how-to-use-attribute-fallthrough-correctly-in-gcc
- https://github.com/eclipse-sumo/sumo/issues/12604 (secondary source for: https://gitlab.freedesktop.org/freetype/freetype/-/commit/ac5babe87629107c43f627e2cd17c6cf4f2ecd43)
- https://lists.gnu.org/archive/html/bug-gnulib/2023-02/msg00159.html (current repo head: https://github.com/coreutils/gnulib/blob/master/lib/dfa.c)

This test should work for MSVC, where C17 support was added in VS 2019 v16.8 and must be turned on explicitly with switch `/std:c17` (resulting definition: `[[fallthrough]]`). In other cases, this test should fall back to default case.